### PR TITLE
wrapper for paths for settings & log file. envvar catch stdin for the…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
 append.sh
-
+run.sh

--- a/src/bin/irotate.rs
+++ b/src/bin/irotate.rs
@@ -1,5 +1,8 @@
 use inotify::{EventMask, Inotify, WatchMask};
-use std::{path::PathBuf, sync::Mutex};
+use std::{
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
 
 #[path = "../files.rs"]
 mod files;
@@ -8,24 +11,53 @@ mod settings;
 
 use files::{FileObj, FileTrait};
 use log::info;
+use settings::FileSize;
+use std::env;
+
+struct FileWatch {
+    location: PathBuf,
+}
+
+impl FileWatch {
+    fn new(path: PathBuf) -> Self {
+        FileWatch { location: path }
+    }
+
+    fn get_size(&self) -> u64 {
+        assert!(self.location.exists());
+        FileSize::from(FileObj::from(self.location.clone())).into()
+    }
+
+    fn get_file_size(&self) -> u64 {
+        self.location.metadata().unwrap().len()
+    }
+}
 
 fn main() {
     env_logger::init();
+    let file_location = env::var("LOG_FILE").expect("no log file stated ");
+    let settings_location =
+        env::var("SETTINGS_FILE").expect("expected file location for settings used.");
 
-    let mut file = Mutex::new(PathBuf::from("/tmp/inote.json"));
+    let mut log_loc = Mutex::new(FileWatch::new(PathBuf::from(file_location).to_owned()));
+    let mut setting_loc = Mutex::new(FileWatch::new(PathBuf::from(settings_location).to_owned()));
+
+    let mut size_desired: u64 = setting_loc.get_mut().unwrap().get_size();
+
     let mut inotify = Inotify::init().expect("Failed to init inotify");
-    let file_inner = file.get_mut().unwrap();
-
-    assert!(file_inner.exists());
-
     let mut watches = inotify.watches();
+
     watches
-        .add(&file_inner, WatchMask::MODIFY)
+        .add(&log_loc.get_mut().unwrap().location, WatchMask::MODIFY)
         .expect("failed to watch required file.");
 
-    let mut buffer = [0u8; 4096];
+    let settings_fd = watches
+        .add(&setting_loc.get_mut().unwrap().location, WatchMask::MODIFY)
+        .expect("failed to load settings file");
 
+    let mut buffer = [0u8; 4096];
     info!("Watching file size change");
+
     loop {
         let events = inotify
             .read_events_blocking(&mut buffer)
@@ -33,11 +65,15 @@ fn main() {
 
         for event in events {
             if event.mask.contains(EventMask::MODIFY) {
-                let file_inner = file.get_mut().unwrap();
-                let size = file_inner.metadata().unwrap().len();
+                if event.wd == settings_fd {
+                    size_desired = setting_loc.get_mut().unwrap().get_size();
+                }
 
-                if size > 50 {
-                    let file_obj: FileObj = (*file_inner).clone().into();
+                let size: u64 = log_loc.get_mut().unwrap().get_file_size();
+
+                if size > size_desired {
+                    let file_location = &log_loc.get_mut().unwrap().location;
+                    let file_obj: FileObj = file_location.clone().into();
 
                     let count = file_obj.get_highest_count();
                     // rotate files and create an empty original file
@@ -45,8 +81,9 @@ fn main() {
 
                     // remove original fd and add new one to notify with same "MODIFY" params
                     watches.remove(event.wd).unwrap();
-                    watches.add(&file_inner, WatchMask::MODIFY).unwrap();
-
+                    watches
+                        .add(&log_loc.get_mut().unwrap().location, WatchMask::MODIFY)
+                        .unwrap();
                     info!("rotated file");
                 }
 


### PR DESCRIPTION
- use of envvar inputs for settings and log file location
- Pathbuf for the 2 behind mutex to fix borrow checker error raised by use in loop
- FileWatch struct created as basic wrapper for size func
